### PR TITLE
correctly free leaves

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
-const Builder = @import("std").build.Builder;
+const std = @import("std");
+const Builder = std.build.Builder;
 
 pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
@@ -9,6 +10,8 @@ pub fn build(b: *Builder) void {
 
     var main_tests = b.addTest("src/test_art.zig");
     main_tests.setBuildMode(mode);
+    // main_tests.filter = "basic";
+    main_tests.setBuildMode(std.builtin.Mode.ReleaseFast);
     main_tests.linkLibC();
 
     const test_step = b.step("test", "Run library tests");

--- a/src/art.zig
+++ b/src/art.zig
@@ -247,7 +247,10 @@ pub fn Art(comptime T: type) type {
         fn deinitNode(t: *Tree, n: *Node) void {
             switch (n.*) {
                 .empty => return,
-                .leaf => {},
+                .leaf => {
+                    t.a.free(n.leaf.key);
+                    return;
+                },
                 .node4, .node16, .node48, .node256 => {
                     var it = n.childIterator();
                     while (it.next()) |child| {


### PR DESCRIPTION
- switching to std.testing.allocator revealed that leaves weren't freeing their keys