### PR TITLE
tests,bench: fileEachLine() accept lines param.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,6 +26,7 @@ pub fn build(b: *Builder) void {
     });
     tests.linkLibC();
     tests.addModule("art", mod);
+    tests.filter = b.option([]const u8, "test-filter", "test filter");
     const test_step = b.step("test", "Run library tests");
     const main_tests_run = b.addRunArtifact(tests);
     main_tests_run.has_side_effects = true;


### PR DESCRIPTION
bench once again uses eachLineDo().  tests now run faster thanks to the same.  the previous implementation was very slow likely due to excessive re-reading files and doing many syscalls.

* rename fileEachLine() to eachLineDo()
* add test helpers readFileLines() and deinitLines()
* build: add -Dtest-filter option

This is a follow up to #13